### PR TITLE
clean: Simplify version number syntax

### DIFF
--- a/doc-generator/generate.sh
+++ b/doc-generator/generate.sh
@@ -3,10 +3,10 @@
 SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 DOCS_HOME="${SCRIPT_HOME}/../docs"
 DESCRIPTION_HOME="${DOCS_HOME}/description"
-VERSION="v0.8.0"
+VERSION="0.8.0"
 
 rm -rf shellcheck shellcheck.wiki
-git clone -b $VERSION --single-branch --depth 1 https://github.com/koalaman/shellcheck.git
+git clone -b v$VERSION --single-branch --depth 1 https://github.com/koalaman/shellcheck.git
 git clone https://github.com/koalaman/shellcheck.wiki.git
 
 cd shellcheck.wiki

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "shellcheck",
-  "version": "v0.8.0",
+  "version": "0.8.0",
   "patterns": [
     {
       "patternId": "SC1000",


### PR DESCRIPTION
This makes the syntax of the version reported by this tool consistent with all other supported tools.

This inconsistency is visible not only on the Codacy UI but also on the results returned by the `/tools` APIv3 endpoint, and on the [list of tool versions](https://docs.codacy.com/release-notes/cloud/cloud-2022-05/#tool-versions) in the release notes.

Reverts a change that was originally introduced in https://github.com/codacy/codacy-shellcheck/pull/6.

After this pull request is merged, it will be necessary to adjust the change made in https://github.com/codacy/release-notes-tools/pull/89.