### PR TITLE
fix: Remove spurious "v" from version number

### DIFF
--- a/doc-generator/generate.sh
+++ b/doc-generator/generate.sh
@@ -3,7 +3,7 @@
 SCRIPT_HOME="$( cd "$( dirname "$0" )" && pwd )"
 DOCS_HOME="${SCRIPT_HOME}/../docs"
 DESCRIPTION_HOME="${DOCS_HOME}/description"
-VERSION="v0.9.0"
+VERSION="0.9.0"
 
 rm -rf shellcheck shellcheck.wiki
 git clone -b v$VERSION --single-branch --depth 1 https://github.com/koalaman/shellcheck.git


### PR DESCRIPTION
I noticed that the latest ShellCheck bump includes a spurious "v" at the start of the version number while [generating the release notes](https://codacy.atlassian.net/browse/DOCS-336). Besides breaking the automatic generation of a link to the changelog of the new tool version:

* This seems to be a bug because the script `doc-generator/generate.sh` will then fail to checkout the correct tag from the ShellCheck Git repository
* All other tools use the `<Major>.<minor>.<patch>` version syntax or similar, without including the "v" prefix